### PR TITLE
ci(build): remove empty build_depends.repos

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -28,4 +28,8 @@
 - repository: autowarefoundation/autoware_common
   files:
     - source: .github/workflows/build-and-test.yaml
+      pre-commands: |
+        sed -i '/build-depends-repos/d' {source}
     - source: .github/workflows/build-and-test-differential.yaml
+      pre-commands: |
+        sed -i '/build-depends-repos/d' {source}

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -16,10 +16,8 @@ jobs:
         include:
           - rosdistro: galactic
             container: ros:galactic
-            build-depends-repos: build_depends.repos
           - rosdistro: humble
             container: ros:humble
-            build-depends-repos: build_depends.repos
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -39,7 +37,6 @@ jobs:
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
-          build-depends-repos: ${{ matrix.build-depends-repos }}
 
       - name: Test
         id: test
@@ -48,7 +45,6 @@ jobs:
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
-          build-depends-repos: ${{ matrix.build-depends-repos }}
 
       - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' }}
@@ -83,4 +79,3 @@ jobs:
           rosdistro: humble
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
           clang-tidy-config-url: https://raw.githubusercontent.com/autowarefoundation/autoware/main/.clang-tidy
-          build-depends-repos: build_depends.repos

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -20,10 +20,8 @@ jobs:
         include:
           - rosdistro: galactic
             container: ros:galactic
-            build-depends-repos: build_depends.repos
           - rosdistro: humble
             container: ros:humble
-            build-depends-repos: build_depends.repos
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -41,7 +39,6 @@ jobs:
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
-          build-depends-repos: ${{ matrix.build-depends-repos }}
 
       - name: Test
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
@@ -50,7 +47,6 @@ jobs:
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
-          build-depends-repos: ${{ matrix.build-depends-repos }}
 
       - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' }}

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -1,1 +1,0 @@
-repositories:


### PR DESCRIPTION
Same as https://github.com/autowarefoundation/autoware_adapi_msgs/pull/7.