### PR TITLE
feat(autoware_perception_msgs): add traffic light messages

### DIFF
--- a/autoware_perception_msgs/CMakeLists.txt
+++ b/autoware_perception_msgs/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_perception_msgs)
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/TrafficLight.msg"
+  "msg/TrafficLightArray.msg"
+  "msg/TrafficLightElement.msg"
+  "msg/TrafficSignal.msg"
+  "msg/TrafficSignalArray.msg"
+  DEPENDENCIES
+    builtin_interfaces
+)
+
+ament_auto_package()

--- a/autoware_perception_msgs/README.md
+++ b/autoware_perception_msgs/README.md
@@ -1,0 +1,23 @@
+# autoware_perception_msgs
+
+## TrafficLightElement.msg
+
+This is the element of traffic lights such as red, amber, green, and turn arrow. The elements are based on Vienna Convention on Road Signs and Signals.
+
+## TrafficLight.msg
+
+For each direction of an intersection, there are typically multiple traffic lights installed for visibility.
+This message represents the traffic light as equipment and is used by components such as percption.
+
+## TrafficSignal.msg
+
+For each direction of an intersection, there is one state of traffic signal regardless of the number of equipment.
+This message represents the traffic signal as a concept and is used by components such as planning.
+
+## TrafficLigntArray.msg
+
+This is a plural type of TrafficLight.msg.
+
+## TrafficSignalArray.msg
+
+This is a plural type of TrafficSignal.msg.

--- a/autoware_perception_msgs/README.md
+++ b/autoware_perception_msgs/README.md
@@ -7,14 +7,14 @@ This is the element of traffic lights such as red, amber, green, and turn arrow.
 ## TrafficLight.msg
 
 For each direction of an intersection, there are typically multiple traffic lights installed for visibility.
-This message represents the traffic light as equipment and is used by components such as percption.
+This message represents the traffic light as equipment and is used by components such as perception.
 
 ## TrafficSignal.msg
 
 For each direction of an intersection, there is one state of traffic signal regardless of the number of equipment.
 This message represents the traffic signal as a concept and is used by components such as planning.
 
-## TrafficLigntArray.msg
+## TrafficLightArray.msg
 
 This is a plural type of TrafficLight.msg.
 

--- a/autoware_perception_msgs/msg/TrafficLight.msg
+++ b/autoware_perception_msgs/msg/TrafficLight.msg
@@ -1,0 +1,2 @@
+int64 traffic_light_id
+autoware_perception_msgs/TrafficLightElement[] elements

--- a/autoware_perception_msgs/msg/TrafficLightArray.msg
+++ b/autoware_perception_msgs/msg/TrafficLightArray.msg
@@ -1,0 +1,2 @@
+builtin_interfaces/Time stamp
+autoware_perception_msgs/TrafficLight[] lights

--- a/autoware_perception_msgs/msg/TrafficLightElement.msg
+++ b/autoware_perception_msgs/msg/TrafficLightElement.msg
@@ -1,0 +1,29 @@
+# constants for color
+uint8 RED = 1
+uint8 AMBER = 2
+uint8 GREEN = 3
+uint8 WHITE = 4
+
+# constants for shape
+uint8 CIRCLE = 5
+uint8 LEFT_ARROW = 6
+uint8 RIGHT_ARROW = 7
+uint8 UP_ARROW = 8
+uint8 DOWN_ARROW = 9
+uint8 DOWN_LEFT_ARROW = 10
+uint8 DOWN_RIGHT_ARROW = 11
+uint8 CROSS = 12
+
+# constants for status
+uint8 SOLID_OFF = 13
+uint8 SOLID_ON = 14
+uint8 FLASHING = 15
+
+# constants for common use
+uint8 UNKNOWN = 16
+
+# variables
+uint8 color
+uint8 shape
+uint8 status
+float32 confidence

--- a/autoware_perception_msgs/msg/TrafficLightElement.msg
+++ b/autoware_perception_msgs/msg/TrafficLightElement.msg
@@ -1,3 +1,6 @@
+# constants for common use
+uint8 UNKNOWN = 0
+
 # constants for color
 uint8 RED = 1
 uint8 AMBER = 2
@@ -5,22 +8,19 @@ uint8 GREEN = 3
 uint8 WHITE = 4
 
 # constants for shape
-uint8 CIRCLE = 5
-uint8 LEFT_ARROW = 6
-uint8 RIGHT_ARROW = 7
-uint8 UP_ARROW = 8
-uint8 DOWN_ARROW = 9
-uint8 DOWN_LEFT_ARROW = 10
-uint8 DOWN_RIGHT_ARROW = 11
-uint8 CROSS = 12
+uint8 CIRCLE = 1
+uint8 LEFT_ARROW = 2
+uint8 RIGHT_ARROW = 3
+uint8 UP_ARROW = 4
+uint8 DOWN_ARROW = 5
+uint8 DOWN_LEFT_ARROW = 6
+uint8 DOWN_RIGHT_ARROW = 7
+uint8 CROSS = 8
 
 # constants for status
-uint8 SOLID_OFF = 13
-uint8 SOLID_ON = 14
-uint8 FLASHING = 15
-
-# constants for common use
-uint8 UNKNOWN = 16
+uint8 SOLID_OFF = 1
+uint8 SOLID_ON = 2
+uint8 FLASHING = 3
 
 # variables
 uint8 color

--- a/autoware_perception_msgs/msg/TrafficSignal.msg
+++ b/autoware_perception_msgs/msg/TrafficSignal.msg
@@ -1,0 +1,2 @@
+int64 traffic_signal_id
+autoware_perception_msgs/TrafficLightElement[] elements

--- a/autoware_perception_msgs/msg/TrafficSignalArray.msg
+++ b/autoware_perception_msgs/msg/TrafficSignalArray.msg
@@ -1,0 +1,2 @@
+builtin_interfaces/Time stamp
+autoware_perception_msgs/TrafficSignal[] signals

--- a/autoware_perception_msgs/package.xml
+++ b/autoware_perception_msgs/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_perception_msgs</name>
+  <version>1.0.0</version>
+  <description>Autoware perception messages package.</description>
+  <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <depend>builtin_interfaces</depend>
+  <depend>rosidl_default_generators</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Signed-off-by: Takagi, Isamu <isamu.takagi@tier4.jp>

## Description

Add traffic light messages.

## Related links

https://github.com/autowarefoundation/autoware.universe/issues/2567

## Tests performed

Build passed.

## Notes for reviewers

None.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
