### PR TITLE
feat: remove set route service

### DIFF
--- a/autoware_planning_msgs/CMakeLists.txt
+++ b/autoware_planning_msgs/CMakeLists.txt
@@ -9,7 +9,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/LaneletRoute.msg"
   "msg/LaneletSegment.msg"
   "msg/PoseWithUuidStamped.msg"
-  "srv/SetRoute.srv"
   "srv/SetPoseWithUuidStamped.srv"
   DEPENDENCIES
     autoware_common_msgs

--- a/autoware_planning_msgs/srv/SetRoute.srv
+++ b/autoware_planning_msgs/srv/SetRoute.srv
@@ -1,5 +1,0 @@
-std_msgs/Header header
-geometry_msgs/Pose goal
-autoware_planning_msgs/LaneletSegment[] segments
----
-autoware_common_msgs/ResponseStatus status


### PR DESCRIPTION
## Description

SetRoute is no longer needed as ADAPI types can be used. See https://github.com/autowarefoundation/autoware.universe/pull/3412 for details.
This PR should be merged after the PR above.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
