### PR TITLE
feat(autoware_planning_msgs): remove SetPoseWithUuidStamped

### DIFF
--- a/autoware_planning_msgs/CMakeLists.txt
+++ b/autoware_planning_msgs/CMakeLists.txt
@@ -9,7 +9,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/LaneletRoute.msg"
   "msg/LaneletSegment.msg"
   "msg/PoseWithUuidStamped.msg"
-  "srv/SetPoseWithUuidStamped.srv"
+  "srv/SetRouteWithUuid.srv"
   DEPENDENCIES
     autoware_common_msgs
     geometry_msgs

--- a/autoware_planning_msgs/CMakeLists.txt
+++ b/autoware_planning_msgs/CMakeLists.txt
@@ -9,9 +9,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/LaneletRoute.msg"
   "msg/LaneletSegment.msg"
   "msg/PoseWithUuidStamped.msg"
-  "srv/SetRouteWithUuid.srv"
   DEPENDENCIES
-    autoware_common_msgs
     geometry_msgs
     std_msgs
     unique_identifier_msgs

--- a/autoware_planning_msgs/package.xml
+++ b/autoware_planning_msgs/package.xml
@@ -11,7 +11,6 @@
 
   <build_depend>rosidl_default_generators</build_depend>
 
-  <depend>autoware_common_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
   <depend>unique_identifier_msgs</depend>

--- a/autoware_planning_msgs/srv/SetPoseWithUuidStamped.srv
+++ b/autoware_planning_msgs/srv/SetPoseWithUuidStamped.srv
@@ -1,4 +1,0 @@
-autoware_planning_msgs/PoseWithUuidStamped data
-bool allow_modification
----
-autoware_common_msgs/ResponseStatus status

--- a/autoware_planning_msgs/srv/SetRouteWithUuid.srv
+++ b/autoware_planning_msgs/srv/SetRouteWithUuid.srv
@@ -1,0 +1,6 @@
+std_msgs/Header header
+geometry_msgs/Pose goal_pose
+unique_identifier_msgs/UUID uuid
+bool allow_modification
+---
+autoware_common_msgs/ResponseStatus status

--- a/autoware_planning_msgs/srv/SetRouteWithUuid.srv
+++ b/autoware_planning_msgs/srv/SetRouteWithUuid.srv
@@ -1,6 +1,0 @@
-std_msgs/Header header
-geometry_msgs/Pose goal_pose
-unique_identifier_msgs/UUID uuid
-bool allow_modification
----
-autoware_common_msgs/ResponseStatus status


### PR DESCRIPTION
## Description

Rename `SetPoseWithUuidStamped` to `SetRouteWithUuid`.
From this comment: https://github.com/autowarefoundation/autoware.universe/pull/3299#discussion_r1168672166.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
