### PR TITLE
fix(autoware_perception_msgs): add Header to tlr messages and change TrafficLightElement.msg status

### DIFF
--- a/autoware_perception_msgs/CMakeLists.txt
+++ b/autoware_perception_msgs/CMakeLists.txt
@@ -11,7 +11,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/TrafficSignal.msg"
   "msg/TrafficSignalArray.msg"
   DEPENDENCIES
-    builtin_interfaces
+    std_msgs
 )
 
 ament_auto_package()

--- a/autoware_perception_msgs/msg/TrafficLightArray.msg
+++ b/autoware_perception_msgs/msg/TrafficLightArray.msg
@@ -1,2 +1,2 @@
-builtin_interfaces/Time stamp
+std_msgs/Header header
 autoware_perception_msgs/TrafficLight[] lights

--- a/autoware_perception_msgs/msg/TrafficLightElement.msg
+++ b/autoware_perception_msgs/msg/TrafficLightElement.msg
@@ -12,10 +12,12 @@ uint8 CIRCLE = 1
 uint8 LEFT_ARROW = 2
 uint8 RIGHT_ARROW = 3
 uint8 UP_ARROW = 4
-uint8 DOWN_ARROW = 5
-uint8 DOWN_LEFT_ARROW = 6
-uint8 DOWN_RIGHT_ARROW = 7
-uint8 CROSS = 8
+uint8 UP_LEFT_ARROW=5
+uint8 UP_RIGHT_ARROW=6
+uint8 DOWN_ARROW = 7
+uint8 DOWN_LEFT_ARROW = 8
+uint8 DOWN_RIGHT_ARROW = 9
+uint8 CROSS = 10
 
 # constants for status
 uint8 SOLID_OFF = 1

--- a/autoware_perception_msgs/msg/TrafficLightElement.msg
+++ b/autoware_perception_msgs/msg/TrafficLightElement.msg
@@ -8,21 +8,21 @@ uint8 GREEN = 3
 uint8 WHITE = 4
 
 # constants for shape
-uint8 CIRCLE = 1
-uint8 LEFT_ARROW = 2
-uint8 RIGHT_ARROW = 3
-uint8 UP_ARROW = 4
-uint8 UP_LEFT_ARROW=5
-uint8 UP_RIGHT_ARROW=6
-uint8 DOWN_ARROW = 7
-uint8 DOWN_LEFT_ARROW = 8
-uint8 DOWN_RIGHT_ARROW = 9
-uint8 CROSS = 10
+uint8 CIRCLE = 5
+uint8 LEFT_ARROW = 6
+uint8 RIGHT_ARROW = 7
+uint8 UP_ARROW = 8
+uint8 UP_LEFT_ARROW = 9
+uint8 UP_RIGHT_ARROW = 10
+uint8 DOWN_ARROW = 11
+uint8 DOWN_LEFT_ARROW = 12
+uint8 DOWN_RIGHT_ARROW = 13
+uint8 CROSS = 14
 
 # constants for status
-uint8 SOLID_OFF = 1
-uint8 SOLID_ON = 2
-uint8 FLASHING = 3
+uint8 SOLID_OFF = 15
+uint8 SOLID_ON = 16
+uint8 FLASHING = 17
 
 # variables
 uint8 color

--- a/autoware_perception_msgs/msg/TrafficSignalArray.msg
+++ b/autoware_perception_msgs/msg/TrafficSignalArray.msg
@@ -1,2 +1,2 @@
-builtin_interfaces/Time stamp
+std_msgs/Header header
 autoware_perception_msgs/TrafficSignal[] signals

--- a/autoware_perception_msgs/package.xml
+++ b/autoware_perception_msgs/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>builtin_interfaces</depend>
+  <depend>std_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 


### PR DESCRIPTION
This PR contains two modifications:

1. Add header to Traffic Light messages to replace stamps, since it's necessary to use ros2 synchronizer
2. Change values in TrafficLightElement.msg since current traffic light nodes requires the shapes, colors and status have different values.