### PR TITLE
feat(autoware_planning_msgs): add route services

### DIFF
--- a/autoware_planning_msgs/CMakeLists.txt
+++ b/autoware_planning_msgs/CMakeLists.txt
@@ -8,19 +8,23 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/LaneletPrimitive.msg"
   "msg/LaneletRoute.msg"
   "msg/LaneletSegment.msg"
-  "msg/PoseWithUuidStamped.msg"
-  "msg/Trajectory.msg"
-  "msg/TrajectoryPoint.msg"
   "msg/Path.msg"
   "msg/PathPoint.msg"
-  "msg/PathWithLaneId.msg"
   "msg/PathPointWithLaneId.msg"
+  "msg/PathWithLaneId.msg"
+  "msg/PoseWithUuidStamped.msg"
+  "msg/RouteState.msg"
+  "msg/Trajectory.msg"
+  "msg/TrajectoryPoint.msg"
+  "srv/ClearRoute.srv"
+  "srv/SetLaneletRoute.srv"
+  "srv/SetWaypointRoute.srv"
   DEPENDENCIES
+    autoware_common_msgs
+    builtin_interfaces
     geometry_msgs
     std_msgs
     unique_identifier_msgs
-    nav_msgs
-    builtin_interfaces
   ADD_LINTER_TESTS
 )
 

--- a/autoware_planning_msgs/msg/RouteState.msg
+++ b/autoware_planning_msgs/msg/RouteState.msg
@@ -1,0 +1,11 @@
+uint8 UNKNOWN = 0
+uint8 INITIALIZING = 1
+uint8 UNSET = 2
+uint8 PLANNING = 3
+uint8 SET = 4
+uint8 REROUTING = 5
+uint8 ARRIVED = 6
+uint8 ABORTED = 7
+
+builtin_interfaces/Time stamp
+uint8 state

--- a/autoware_planning_msgs/package.xml
+++ b/autoware_planning_msgs/package.xml
@@ -11,9 +11,9 @@
 
   <build_depend>rosidl_default_generators</build_depend>
 
+  <depend>autoware_common_msgs</depend>
   <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
-  <depend>nav_msgs</depend>
   <depend>std_msgs</depend>
   <depend>unique_identifier_msgs</depend>
 

--- a/autoware_planning_msgs/srv/ClearRoute.srv
+++ b/autoware_planning_msgs/srv/ClearRoute.srv
@@ -1,0 +1,2 @@
+---
+autoware_common_msgs/ResponseStatus status

--- a/autoware_planning_msgs/srv/SetLaneletRoute.srv
+++ b/autoware_planning_msgs/srv/SetLaneletRoute.srv
@@ -1,0 +1,11 @@
+std_msgs/Header header
+geometry_msgs/Pose goal_pose
+autoware_planning_msgs/LaneletSegment[] segments
+unique_identifier_msgs/UUID uuid
+bool allow_modification
+---
+uint16 ERROR_INVALID_STATE = 1
+uint16 ERROR_PLANNER_UNREADY = 2
+uint16 ERROR_PLANNER_FAILED = 3
+uint16 ERROR_REROUTE_FAILED = 4
+autoware_common_msgs/ResponseStatus status

--- a/autoware_planning_msgs/srv/SetWaypointRoute.srv
+++ b/autoware_planning_msgs/srv/SetWaypointRoute.srv
@@ -1,0 +1,11 @@
+std_msgs/Header header
+geometry_msgs/Pose goal_pose
+geometry_msgs/Pose[] waypoints
+unique_identifier_msgs/UUID uuid
+bool allow_modification
+---
+uint16 ERROR_INVALID_STATE = 1
+uint16 ERROR_PLANNER_UNREADY = 2
+uint16 ERROR_PLANNER_FAILED = 3
+uint16 ERROR_REROUTE_FAILED = 4
+autoware_common_msgs/ResponseStatus status


### PR DESCRIPTION
## Description

Add internal route messages/services for https://github.com/autowarefoundation/autoware.universe/issues/6319.
- `SetLanaletRoute` is almost the same as ADAPI `SetRoute` with the addition of a UUID.
- `SetWaypointsRoute` is almost the same as ADAPI `SetRoutePoints` with the addition of a UUID.
- `ClearRoute` is the same as ADAPI, but I copied it so that it is in the same package as the other services.
- `RouteState` is based on the ADAPI, with additional intermediate states used for communication between nodes.

## Related links

https://github.com/autowarefoundation/autoware.universe/issues/6319

## Tests performed

N/A

## Notes for reviewers

None

## Interface changes

Add following messages/services to autoware_planning_msgs
- SetLanaletRoute
- SetWaypointsRoute
- ClearRoute
- RouteState

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
