### PR TITLE
feat(autoware_msgs): add new optional messages package with published time debug message

### DIFF
--- a/autoware_optional_msgs/CMakeLists.txt
+++ b/autoware_optional_msgs/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_optional_msgs)
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+set(msg_files
+  "msg/PublishedTime.msg")
+
+set(msg_dependencies
+  builtin_interfaces)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  DEPENDENCIES ${msg_dependencies}
+)
+
+ament_auto_package()

--- a/autoware_optional_msgs/msg/PublishedTime.msg
+++ b/autoware_optional_msgs/msg/PublishedTime.msg
@@ -1,0 +1,7 @@
+# The debug message which includes header and publishing timestamp
+
+# Message header time
+builtin_interfaces/Time header_stamp
+
+# Timestamp when the message was published
+builtin_interfaces/Time published_stamp

--- a/autoware_optional_msgs/package.xml
+++ b/autoware_optional_msgs/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_optional_msgs</name>
+  <version>1.0.0</version>
+  <description>Autoware optional messages package.</description>
+  <maintainer email="berkay@leodrive.ai">Berkay Karaman</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <depend>builtin_interfaces</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Closes: https://github.com/autowarefoundation/autoware.universe/issues/6255

We want to add a new message which will report the header time and published time of a message inside the pipelines.
## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
