### PR TITLE
fix(autoware_vehicle_msgs): remove ControlModeCommands.msg in CMakeLists.txt

### DIFF
--- a/autoware_vehicle_msgs/CMakeLists.txt
+++ b/autoware_vehicle_msgs/CMakeLists.txt
@@ -9,7 +9,6 @@ find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
 rosidl_generate_interfaces(${PROJECT_NAME}
-    "msg/ControlModeCommand.msg"
     "msg/ControlModeReport.msg"
     "msg/Engage.msg"
     "msg/GearCommand.msg"


### PR DESCRIPTION
## Description
Fixes build error from https://github.com/autowarefoundation/autoware_msgs/pull/89

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
