### PR TITLE
feat(autoware_planning_msgs): add messages for the mapless_architecture

### DIFF
--- a/autoware_planning_msgs/CMakeLists.txt
+++ b/autoware_planning_msgs/CMakeLists.txt
@@ -13,6 +13,14 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/TrajectoryPoint.msg"
   "msg/Path.msg"
   "msg/PathPoint.msg"
+  "msg/DrivingCorridor.msg"
+  "msg/MissionLanesStamped.msg"
+  "msg/Mission.msg"
+  "msg/VisualizationDistance.msg"
+  "msg/Segment.msg"
+  "msg/RoadSegments.msg"
+  "msg/Linestring.msg"
+  "msg/LocalMap.msg"
   DEPENDENCIES
     geometry_msgs
     std_msgs

--- a/autoware_planning_msgs/msg/DrivingCorridor.msg
+++ b/autoware_planning_msgs/msg/DrivingCorridor.msg
@@ -1,0 +1,4 @@
+geometry_msgs/Point[] centerline
+geometry_msgs/Point[] bound_left
+geometry_msgs/Point[] bound_right
+uint8 type

--- a/autoware_planning_msgs/msg/Linestring.msg
+++ b/autoware_planning_msgs/msg/Linestring.msg
@@ -1,0 +1,1 @@
+geometry_msgs/Pose[] poses # Store the points here

--- a/autoware_planning_msgs/msg/LocalMap.msg
+++ b/autoware_planning_msgs/msg/LocalMap.msg
@@ -1,3 +1,3 @@
 RoadSegments road_segments
 
-# More messages will be added here later (sign detection, HD maps, ...)
+# More data fields will be added here later (sign detection, HD maps, ...)

--- a/autoware_planning_msgs/msg/LocalMap.msg
+++ b/autoware_planning_msgs/msg/LocalMap.msg
@@ -1,0 +1,3 @@
+RoadSegments road_segments
+
+# More messages will be added here later (sign detection, HD maps, ...)

--- a/autoware_planning_msgs/msg/Mission.msg
+++ b/autoware_planning_msgs/msg/Mission.msg
@@ -6,4 +6,4 @@ uint8 LANE_CHANGE_RIGHT=2
 uint8 TAKE_NEXT_EXIT_LEFT=3
 uint8 TAKE_NEXT_EXIT_RIGHT=4
 
-float32 deadline
+float32 deadline # Spatial deadline parameter (meters), the mission should be completed after this number of meters

--- a/autoware_planning_msgs/msg/Mission.msg
+++ b/autoware_planning_msgs/msg/Mission.msg
@@ -1,0 +1,9 @@
+# Enum mission_type
+uint8 mission_type
+uint8 LANE_KEEP=0
+uint8 LANE_CHANGE_LEFT=1
+uint8 LANE_CHANGE_RIGHT=2
+uint8 TAKE_NEXT_EXIT_LEFT=3
+uint8 TAKE_NEXT_EXIT_RIGHT=4
+
+float32 deadline

--- a/autoware_planning_msgs/msg/MissionLanesStamped.msg
+++ b/autoware_planning_msgs/msg/MissionLanesStamped.msg
@@ -4,4 +4,4 @@ DrivingCorridor lane_with_goal_point
 DrivingCorridor ego_lane
 DrivingCorridor[] drivable_lanes_left
 DrivingCorridor[] drivable_lanes_right
-float32 deadline_target_lane
+float32 deadline_target_lane # Spatial deadline parameter (meters), the target lane should be reached after this number of meters

--- a/autoware_planning_msgs/msg/MissionLanesStamped.msg
+++ b/autoware_planning_msgs/msg/MissionLanesStamped.msg
@@ -1,0 +1,7 @@
+std_msgs/Header header
+int16 target_lane
+DrivingCorridor lane_with_goal_point
+DrivingCorridor ego_lane
+DrivingCorridor[] drivable_lanes_left
+DrivingCorridor[] drivable_lanes_right
+float32 deadline_target_lane

--- a/autoware_planning_msgs/msg/RoadSegments.msg
+++ b/autoware_planning_msgs/msg/RoadSegments.msg
@@ -1,3 +1,3 @@
 std_msgs/Header header
-Segment[] segments
+Segment[] segments # The segments/lanelets
 geometry_msgs/Pose pose

--- a/autoware_planning_msgs/msg/RoadSegments.msg
+++ b/autoware_planning_msgs/msg/RoadSegments.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+Segment[] segments
+geometry_msgs/Pose pose

--- a/autoware_planning_msgs/msg/Segment.msg
+++ b/autoware_planning_msgs/msg/Segment.msg
@@ -1,0 +1,4 @@
+uint16 id
+Linestring[2] linestrings
+int32[] successor_lanelet_id
+int32[] neighboring_lanelet_id

--- a/autoware_planning_msgs/msg/Segment.msg
+++ b/autoware_planning_msgs/msg/Segment.msg
@@ -1,3 +1,5 @@
+# Segments are similar to lanelets.
+
 uint16 id
 Linestring[2] linestrings
 int32[] successor_lanelet_id

--- a/autoware_planning_msgs/msg/VisualizationDistance.msg
+++ b/autoware_planning_msgs/msg/VisualizationDistance.msg
@@ -1,3 +1,3 @@
 # Visualization Message for the distance
 
-float32 distance
+float32 distance # Distance between point and linestring (meters), used for debugging

--- a/autoware_planning_msgs/msg/VisualizationDistance.msg
+++ b/autoware_planning_msgs/msg/VisualizationDistance.msg
@@ -1,0 +1,3 @@
+# Visualization Message for the distance
+
+float32 distance


### PR DESCRIPTION
## Description

We added new messages required for the mapless architecture.

## Related links

Related GitHub discussion: https://github.com/orgs/autowarefoundation/discussions/4545

## Tests performed

This PR was tested using rosbags.

## Notes for reviewers

Related PR in the [autoware.universe](https://github.com/autowarefoundation/autoware.universe) repository: https://github.com/autowarefoundation/autoware.universe/pull/7709

## Interface changes

No interfaces are changed. We just added some new messages.

## Effects on system behavior

The system behavior is not affected.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
