### PR TITLE
feat(autoware_msg): add recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # autoware_msgs
 
 Before contributing, review [the message guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/message-guidelines/).
+
+## Add as conan packages
+
+```sh
+pip install conan2
+mkdir ~/.conan2/profiles
+touch ~/.conan2/profiles/default
+cp profiles/gcc_pf ~/.conan2/profiles/default
+conan install .
+conan build .
+conan create .
+```

--- a/autoware_perception_msgs/conanfile.py
+++ b/autoware_perception_msgs/conanfile.py
@@ -1,0 +1,51 @@
+from conan import ConanFile, tools
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
+from conan.tools.files import copy
+import os
+
+class App(ConanFile):
+    name = "autoware_perception_msgs"
+    version = "0.0.0"
+    # Optional metadata
+    license = " "  # Todo
+    topics = ("Base")
+    requires = []
+    # Binary configuration
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "enable_test": ["ON", "OFF"],
+        "enable_coverage": ["ON", "OFF"]
+    }
+    default_options = {
+        "shared": True,
+        "fPIC": True,
+        "enable_test": "ON",
+        "enable_coverage": "ON"
+    }
+
+    generators = "CMakeToolchain", "CMakeDeps"
+
+    def layout(self):
+        build_f = self.settings.get_safe("compiler")
+        cmake_layout(self, src_folder="." , build_folder= "build/"+build_f)
+        self.graph_root = os.getcwd()
+        self.install_folder = self.graph_root +"/build/"
+        self.install_folder = self.install_folder +build_f + "/"+ self.settings.get_safe("build_type")
+
+    def build(self):
+        self.run('export CC="/usr/lib/ccache/gcc"')
+        self.run('export CXX="/usr/lib/ccache/g++"')
+        self.run(
+            'VERBOSE=1 colcon build --continue-on-error --event-handlers console_cohesion+ --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=ON  -DBUILD_SHARED_LIBS=ON --paths="../../../../autoware_perception_msgs"')
+
+    def package(self):
+        # Define the source path where the headers are located after the build
+        install_path = os.path.join(self.install_folder, "install", "autoware_perception_msgs")
+
+        # copying headers from build_folder
+        copy(self, "*", install_path, self.package_folder)
+
+    def package_info(self):
+        self.cpp_info.includedirs = ["include/autoware_perception_msgs"]

--- a/profiles/arm_gcc_pf 
+++ b/profiles/arm_gcc_pf 
@@ -1,0 +1,12 @@
+[settings]
+os=Linux
+arch=armv8
+compiler=gcc
+compiler.version=11.4
+compiler.libcxx=libstdc++11
+build_type=Debug
+[options]
+&:enable_test=ON
+[buildenv]
+CC=gcc
+CXX=g++

--- a/profiles/clang_pf
+++ b/profiles/clang_pf
@@ -1,0 +1,12 @@
+[settings]
+os=Linux
+arch=x86_64
+compiler=clang
+compiler.version=18
+compiler.libcxx=libstdc++11
+build_type=Debug
+[options]
+&:enable_test=ON
+[buildenv]
+CC=clang
+CXX=clang++

--- a/profiles/gcc_pf
+++ b/profiles/gcc_pf
@@ -1,0 +1,12 @@
+[settings]
+os=Linux
+arch=x86_64
+compiler=gcc
+compiler.version=11.4
+compiler.libcxx=libstdc++11
+build_type=Debug
+[options]
+&:enable_test=ON
+[buildenv]
+CC=gcc
+CXX=g++


### PR DESCRIPTION
## Description

To make a conan packages 
[conan_package.zip](https://github.com/user-attachments/files/16977543/conan_package.zip)
. After uploading the conan package to a server, we can download the binary package (lib and includes) of the ros2 packages. In this way we can easily use the autoware packages with a ros2 humble docker. (Without building them again) 
 
## Related links

[add colcon build features as conan extensions](https://github.com/conan-io/conan-extensions/pull/150)

## Tests performed

I have created the conan package of "autoware_perception_msgs/0.0.0" for building the `tier4_perception_msgs` package which has `autoware_perception_msgs/0.0.0` as a dependency.

This line should be added to the Cmakelist of `tier4_perception_msgs` to find the conan_toolchain and include file of the conan dependencies.

```
include(${CMAKE_BINARY_DIR}/../../generators/conan_toolchain.cmake)
include_directories(${CMAKE_INCLUDE_PATH})
```

It the conanfile.py of the tier4_perception_msgs

```py
from conan import ConanFile, tools
from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
import os
from conan.tools.files import copy

class App(ConanFile):
    name = "tier4_perception_msgs"
    version = "0.0.0" 
    # Optional metadata
    license = " "  # Todo
    topics = ("Base")
    requires = [
        "autoware_perception_msgs/0.0.0"
    ]
    # Binary configuration
    settings = "os", "compiler", "build_type", "arch"
    options = {
        "shared": [True, False],
        "fPIC": [True, False],
        "enable_test": ["ON", "OFF"],
        "enable_coverage": ["ON", "OFF"]
    }
    default_options = {
        "shared": True,
        "fPIC": True,
        "enable_test": "ON",
        "enable_coverage": "ON"
    }
    generators = "CMakeToolchain", "CMakeDeps"
    graph_root = os.getcwd()
    
    def layout(self):
        build_f = self.settings.get_safe("compiler")
        cmake_layout(self, src_folder="." , build_folder= "build/"+build_f)
        self.graph_root = os.getcwd()
        self.install_folder = self.graph_root +"/build/"
        self.install_folder = self.install_folder +build_f + "/"+ self.settings.get_safe("build_type")

    def build(self):
        self.run('export CC="/usr/lib/ccache/gcc"')
        self.run('export CXX="/usr/lib/ccache/g++"')
        self.run(
            'VERBOSE=1 colcon build --continue-on-error --event-handlers console_cohesion+ --cmake-args -DCMAKE_TOOLCHAIN_FILE=generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=ON  -DBUILD_SHARED_LIBS=ON --paths="../../../../tier4_perception_msgs"')
        
    def package(self):
        # Define the source path where the headers are located after the build
        install_path = os.path.join(self.install_folder, "install", "tier4_perception_msgs")
        
        # copying headers from build_folder
        copy(self, "*", install_path, self.package_folder)
        
    def package_info(self):
        self.cpp_info.includedirs = ["include/tier4_perception_msgs"]
```
## Notes for reviewers

I can update the conanfile for other msgs as well. But for now to make the review easier we need to agree on the format of the conan recipes.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

we need to add conan2 on the docker
````
pip install conan2
````

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x ] I've confirmed the [contribution guidelines].
- [ x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
