### PR TITLE
feat(autoware_map_msgs): add MapProjectorInfo message

### DIFF
--- a/autoware_map_msgs/CMakeLists.txt
+++ b/autoware_map_msgs/CMakeLists.txt
@@ -9,6 +9,7 @@ set(msg_files
   "msg/LaneletMapBin.msg"
   "msg/LaneletMapMetaData.msg"
   "msg/LaneletMapCellMetaData.msg"
+  "msg/MapProjectorInfo.msg"
   "msg/PointCloudMapCellWithID.msg"
   "msg/PointCloudMapCellMetaData.msg"
   "msg/PointCloudMapCellMetaDataWithID.msg"
@@ -21,6 +22,7 @@ set(msg_files
 set(msg_dependencies
   std_msgs
   geometry_msgs
+  geographic_msgs
   sensor_msgs)
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/autoware_map_msgs/README.md
+++ b/autoware_map_msgs/README.md
@@ -14,7 +14,7 @@ The message contains a pointcloud meta data attached with an ID. These IDs are i
 
 ## MapProjectorInfo.msg
 
-The message contains the information required to project global coordinates to local coodraintes used by Autoware, which includes the name of the projection method and the parameters for the projection.
+The message contains the information required to project global coordinates to local coordinates used by Autoware, which includes the name of the projection method and the parameters for the projection.
 For further information, please refer to the readme of [map_projection_loader](https://github.com/autowarefoundation/autoware.universe/blob/main/map/autoware_map_projection_loader/README.md) in Autoware Universe.
 
 ## GetPartialPointCloudMap.srv

--- a/autoware_map_msgs/README.md
+++ b/autoware_map_msgs/README.md
@@ -12,6 +12,12 @@ The message contains a pointcloud data attached with an ID.
 
 The message contains a pointcloud meta data attached with an ID. These IDs are intended to be used as a query for selected PCD map loading (see `GetSelectedPointCloudMap.srv` section).
 
+## MapProjectorInfo.msg
+
+The message contains the information required to project global coordinates to local coodraintes used by Autoware, which includes the name of the projection method and the parameters for the projection.
+For further information, please refer to the readme of [map_projection_loader](https://github.com/autowarefoundation/autoware.universe/blob/main/map/autoware_map_projection_loader/README.md) in Autoware Universe.
+
+
 ## GetPartialPointCloudMap.srv
 
 Given an area query (`AreaInfo`), the response is expected to contain the PCD maps (each of which attached with unique ID) whose area overlaps with the query.
@@ -37,3 +43,4 @@ Let $X_0$ be a set of PCD map ID that the client node has, $X_1$ be a set of PCD
 ## GetSelectedPointCloudMap.srv
 
 Given IDs query, the response is expected to contain the PCD maps (each of which attached with unique ID) specified by query. Before using this interface, the client is expected to receive the `PointCloudMapCellMetaDataWithID.msg` metadata to retrieve information about IDs.
+

--- a/autoware_map_msgs/README.md
+++ b/autoware_map_msgs/README.md
@@ -17,7 +17,6 @@ The message contains a pointcloud meta data attached with an ID. These IDs are i
 The message contains the information required to project global coordinates to local coodraintes used by Autoware, which includes the name of the projection method and the parameters for the projection.
 For further information, please refer to the readme of [map_projection_loader](https://github.com/autowarefoundation/autoware.universe/blob/main/map/autoware_map_projection_loader/README.md) in Autoware Universe.
 
-
 ## GetPartialPointCloudMap.srv
 
 Given an area query (`AreaInfo`), the response is expected to contain the PCD maps (each of which attached with unique ID) whose area overlaps with the query.
@@ -43,4 +42,3 @@ Let $X_0$ be a set of PCD map ID that the client node has, $X_1$ be a set of PCD
 ## GetSelectedPointCloudMap.srv
 
 Given IDs query, the response is expected to contain the PCD maps (each of which attached with unique ID) specified by query. Before using this interface, the client is expected to receive the `PointCloudMapCellMetaDataWithID.msg` metadata to retrieve information about IDs.
-

--- a/autoware_map_msgs/msg/MapProjectorInfo.msg
+++ b/autoware_map_msgs/msg/MapProjectorInfo.msg
@@ -1,0 +1,18 @@
+# Projector type
+string LOCAL = "local"
+string LOCAL_CARTESIAN_UTM = "LocalCartesianUTM"
+string MGRS = "MGRS"
+string TRANSVERSE_MERCATOR = "TransverseMercator"
+string projector_type
+
+# Vertical datum
+string WGS84 = "WGS84"
+string EGM2008 = "EGM2008"
+string vertical_datum
+
+# Used for MGRS map
+string mgrs_grid
+
+# Used for some map projection types
+# altitude may not be in ellipsoid height
+geographic_msgs/GeoPoint map_origin

--- a/autoware_map_msgs/msg/MapProjectorInfo.msg
+++ b/autoware_map_msgs/msg/MapProjectorInfo.msg
@@ -1,5 +1,5 @@
 # Projector type
-string LOCAL = "local"
+string LOCAL = "Local"
 string LOCAL_CARTESIAN_UTM = "LocalCartesianUTM"
 string MGRS = "MGRS"
 string TRANSVERSE_MERCATOR = "TransverseMercator"

--- a/autoware_map_msgs/package.xml
+++ b/autoware_map_msgs/package.xml
@@ -14,8 +14,8 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <depend>geometry_msgs</depend>
   <depend>geographic_msgs</depend>
+  <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
 

--- a/autoware_map_msgs/package.xml
+++ b/autoware_map_msgs/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>geometry_msgs</depend>
+  <depend>geographic_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
 


### PR DESCRIPTION
## Description
This ports the MapProjectorInfo message from tier4_autoware_map_msgs to autoware_map_msgs.
This message is already defined as a interface in Autoware Design Document for Map module and should be added as Autoware's core interface. 

I would like to merge them before I port map_loader packages into Autoware Core from Universe.

## Related links
- https://github.com/autowarefoundation/autoware_msgs/issues/103
- https://github.com/tier4/tier4_autoware_msgs/tree/tier4/universe/tier4_map_msgs/msg
- https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-architecture/map/#projection-information

## Tests performed
I have tested that it build properly on my local machine

## Notes for reviewers

none

## Interface changes

Addes new message: MapProjectorInfo message

## Effects on system behavior

No effects until the packages that use tier4_autoware_msgs/MapProjectorInfo is replaced. 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
