### PR TITLE
feat(autoware_debug_msgs): move messages from tier4_debug_msgs

### DIFF
--- a/autoware_debug_msgs/CMakeLists.txt
+++ b/autoware_debug_msgs/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.5)
+project(autoware_debug_msgs)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/MultiArrayDimension.msg"
+  "msg/MultiArrayLayout.msg"
+  "msg/BoolStamped.msg"
+  "msg/Float32Stamped.msg"
+  "msg/Float32MultiArrayStamped.msg"
+  "msg/Float64Stamped.msg"
+  "msg/Float64MultiArrayStamped.msg"
+  "msg/Int32Stamped.msg"
+  "msg/Int32MultiArrayStamped.msg"
+  "msg/Int64Stamped.msg"
+  "msg/Int64MultiArrayStamped.msg"
+  "msg/StringStamped.msg"
+  "msg/ProcessingTimeNode.msg"
+  "msg/ProcessingTimeTree.msg"
+  DEPENDENCIES
+  builtin_interfaces
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_auto_package()

--- a/autoware_debug_msgs/msg/BoolStamped.msg
+++ b/autoware_debug_msgs/msg/BoolStamped.msg
@@ -1,0 +1,2 @@
+builtin_interfaces/Time stamp
+bool data

--- a/autoware_debug_msgs/msg/Float32MultiArrayStamped.msg
+++ b/autoware_debug_msgs/msg/Float32MultiArrayStamped.msg
@@ -1,0 +1,3 @@
+builtin_interfaces/Time stamp
+autoware_debug_msgs/MultiArrayLayout layout
+float32[] data

--- a/autoware_debug_msgs/msg/Float32Stamped.msg
+++ b/autoware_debug_msgs/msg/Float32Stamped.msg
@@ -1,0 +1,2 @@
+builtin_interfaces/Time stamp
+float32 data

--- a/autoware_debug_msgs/msg/Float64MultiArrayStamped.msg
+++ b/autoware_debug_msgs/msg/Float64MultiArrayStamped.msg
@@ -1,0 +1,3 @@
+builtin_interfaces/Time stamp
+autoware_debug_msgs/MultiArrayLayout layout
+float64[] data

--- a/autoware_debug_msgs/msg/Float64Stamped.msg
+++ b/autoware_debug_msgs/msg/Float64Stamped.msg
@@ -1,0 +1,2 @@
+builtin_interfaces/Time stamp
+float64 data

--- a/autoware_debug_msgs/msg/Int32MultiArrayStamped.msg
+++ b/autoware_debug_msgs/msg/Int32MultiArrayStamped.msg
@@ -1,0 +1,3 @@
+builtin_interfaces/Time stamp
+autoware_debug_msgs/MultiArrayLayout layout
+int32[] data

--- a/autoware_debug_msgs/msg/Int32Stamped.msg
+++ b/autoware_debug_msgs/msg/Int32Stamped.msg
@@ -1,0 +1,2 @@
+builtin_interfaces/Time stamp
+int32 data

--- a/autoware_debug_msgs/msg/Int64MultiArrayStamped.msg
+++ b/autoware_debug_msgs/msg/Int64MultiArrayStamped.msg
@@ -1,0 +1,3 @@
+builtin_interfaces/Time stamp
+autoware_debug_msgs/MultiArrayLayout layout
+int64[] data

--- a/autoware_debug_msgs/msg/Int64Stamped.msg
+++ b/autoware_debug_msgs/msg/Int64Stamped.msg
@@ -1,0 +1,2 @@
+builtin_interfaces/Time stamp
+int64 data

--- a/autoware_debug_msgs/msg/MultiArrayDimension.msg
+++ b/autoware_debug_msgs/msg/MultiArrayDimension.msg
@@ -1,0 +1,11 @@
+# This is from ros2 common_interfaces.
+# https://github.com/ros2/common_interfaces/blob/master/std_msgs/msg/MultiArrayDimension.msg
+
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+string label   # label of given dimension
+uint32 size    # size of given dimension (in type units)
+uint32 stride  # stride of given dimension

--- a/autoware_debug_msgs/msg/MultiArrayLayout.msg
+++ b/autoware_debug_msgs/msg/MultiArrayLayout.msg
@@ -1,0 +1,34 @@
+# This is from ros2 common_interfaces.
+# https://github.com/ros2/common_interfaces/blob/master/std_msgs/msg/MultiArrayLayout.msg
+
+# This was originally provided as an example message.
+# It is deprecated as of Foxy
+# It is recommended to create your own semantically meaningful message.
+# However if you would like to continue using this please use the equivalent in example_msgs.
+
+# The multiarray declares a generic multi-dimensional array of a
+# particular data type.  Dimensions are ordered from outer most
+# to inner most.
+#
+# Accessors should ALWAYS be written in terms of dimension stride
+# and specified outer-most dimension first.
+#
+# multiarray(i,j,k) = data[data_offset + dim_stride[1]*i + dim_stride[2]*j + k]
+#
+# A standard, 3-channel 640x480 image with interleaved color channels
+# would be specified as:
+#
+# dim[0].label  = "height"
+# dim[0].size   = 480
+# dim[0].stride = 3*640*480 = 921600  (note dim[0] stride is just size of image)
+# dim[1].label  = "width"
+# dim[1].size   = 640
+# dim[1].stride = 3*640 = 1920
+# dim[2].label  = "channel"
+# dim[2].size   = 3
+# dim[2].stride = 3
+#
+# multiarray(i,j,k) refers to the ith row, jth column, and kth channel.
+
+autoware_debug_msgs/MultiArrayDimension[] dim # Array of dimension properties
+uint32 data_offset        # padding bytes at front of data

--- a/autoware_debug_msgs/msg/ProcessingTimeNode.msg
+++ b/autoware_debug_msgs/msg/ProcessingTimeNode.msg
@@ -1,0 +1,10 @@
+# Unique ID of the node
+int32 id
+# Name of the node
+string name
+# Processing time of the node
+float64 processing_time
+# ID of the parent node, 0 if no parent
+int32 parent_id
+# Comment
+string comment

--- a/autoware_debug_msgs/msg/ProcessingTimeTree.msg
+++ b/autoware_debug_msgs/msg/ProcessingTimeTree.msg
@@ -1,0 +1,2 @@
+# Array of all time nodes
+ProcessingTimeNode[] nodes

--- a/autoware_debug_msgs/msg/StringStamped.msg
+++ b/autoware_debug_msgs/msg/StringStamped.msg
@@ -1,0 +1,2 @@
+builtin_interfaces/Time stamp
+string data

--- a/autoware_debug_msgs/package.xml
+++ b/autoware_debug_msgs/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_debug_msgs</name>
+  <version>0.0.0</version>
+  <description>The autoware_debug_msgs package</description>
+  <maintainer email="horibe.takamasa@gmail.com">Takamasa Horibe</maintainer>
+  <maintainer email="cynthia.liu@autocore.ai">cyn_liu</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+
+  <depend>builtin_interfaces</depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
## Description

Create `autoware_debug_msgs` in `autoware_msgs` repos, and move all still in use messages from `tier4_debug_msgs` to `autoware_debug_msgs`.

I would like to merge them before I port `autoware_universe_utils` packages into Autoware Core from Universe.

## Related links

- https://github.com/autowarefoundation/autoware_msgs/issues/112
- https://github.com/tier4/tier4_autoware_msgs/tree/tier4/universe/tier4_debug_msgs
- https://docs.google.com/document/d/1kKshojZo8RuYQ-WhIqQCqTKQO3ojTb5RB77V3NjYpdU/edit?tab=t.0

## How was this PR tested?

None.

## Notes for reviewers

None.

## Effects on system behavior

None.
