### PR TITLE
feat(autoware_planning_msgs): add VelocityLimit message

### DIFF
--- a/autoware_planning_msgs/CMakeLists.txt
+++ b/autoware_planning_msgs/CMakeLists.txt
@@ -13,6 +13,9 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/TrajectoryPoint.msg"
   "msg/Path.msg"
   "msg/PathPoint.msg"
+  "msg/VelocityLimit.msg"
+  "msg/VelocityLimitConstraints.msg"
+  "msg/VelocityClearCommand.msg"
   DEPENDENCIES
     geometry_msgs
     std_msgs

--- a/autoware_planning_msgs/msg/VelocityLimit.msg
+++ b/autoware_planning_msgs/msg/VelocityLimit.msg
@@ -1,0 +1,7 @@
+builtin_interfaces/Time stamp
+float32 max_velocity
+
+bool use_constraints false
+autoware_planning_msgs/VelocityLimitConstraints constraints
+
+string sender

--- a/autoware_planning_msgs/msg/VelocityLimitClearCommand.msg
+++ b/autoware_planning_msgs/msg/VelocityLimitClearCommand.msg
@@ -1,0 +1,3 @@
+builtin_interfaces/Time stamp
+bool command false
+string sender

--- a/autoware_planning_msgs/msg/VelocityLimitConstraints.msg
+++ b/autoware_planning_msgs/msg/VelocityLimitConstraints.msg
@@ -1,0 +1,11 @@
+# maximum signed acceleration
+float32 max_acceleration
+
+# minimum signed acceleration
+float32 min_acceleration
+
+# maximum signed jerk
+float32 max_jerk
+
+# minimum signed jerk
+float32 min_jerk


### PR DESCRIPTION
## Description
This adds VelocityLimit message from tier4_planning_msgs to prepare for porting planning packages to Autoware Core.
The message is used by autoware_planning_test_manager and behavior_planner_common packages which are included in [porting target packages](https://docs.google.com/spreadsheets/d/1B7w8AHo7MEDexLrvd-8BKDzORzPVg5P2w67g-_K83Vo/edit?gid=0#gid=0). 

### Related Links
- https://github.com/orgs/autowarefoundation/discussions/5365

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
