### PR TITLE
feat(MapProjectorInfo.msg): add LocalCartesian const

### DIFF
--- a/autoware_map_msgs/msg/MapProjectorInfo.msg
+++ b/autoware_map_msgs/msg/MapProjectorInfo.msg
@@ -1,6 +1,7 @@
 # Projector type
 string LOCAL = "Local"
 string LOCAL_CARTESIAN_UTM = "LocalCartesianUTM"
+string LOCAL_CARTESIAN = "LocalCartesian"
 string MGRS = "MGRS"
 string TRANSVERSE_MERCATOR = "TransverseMercator"
 string projector_type


### PR DESCRIPTION
## Description
Add LocalCartesian const to MapProjectionInfo to extend autoware_geography_utils with LocalCartesian (WGS84) projection

Changes required by [this PR](https://github.com/autowarefoundation/autoware.universe/pull/9238) 
## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
