### PR TITLE
feat(autoware_planning_msgs): add route services

### DIFF
--- a/autoware_planning_msgs/CMakeLists.txt
+++ b/autoware_planning_msgs/CMakeLists.txt
@@ -13,7 +13,12 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/TrajectoryPoint.msg"
   "msg/Path.msg"
   "msg/PathPoint.msg"
+  "msg/RouteState.msg"
+  "srv/ClearRoute.srv"
+  "srv/SetLaneletRoute.srv"
+  "srv/SetWaypointRoute.srv"
   DEPENDENCIES
+    autoware_common_msgs
     geometry_msgs
     std_msgs
     unique_identifier_msgs

--- a/autoware_planning_msgs/msg/RouteState.msg
+++ b/autoware_planning_msgs/msg/RouteState.msg
@@ -1,0 +1,12 @@
+uint8 UNKNOWN = 0
+uint8 INITIALIZING = 1
+uint8 UNSET = 2
+uint8 ROUTING = 3
+uint8 SET = 4
+uint8 REROUTING = 5
+uint8 ARRIVED = 6
+uint8 ABORTED = 7
+uint8 INTERRUPTED = 8
+
+builtin_interfaces/Time stamp
+uint8 state

--- a/autoware_planning_msgs/package.xml
+++ b/autoware_planning_msgs/package.xml
@@ -14,8 +14,8 @@
 
   <build_depend>rosidl_default_generators</build_depend>
 
-  <depend>builtin_interfaces</depend>
   <depend>autoware_common_msgs</depend>
+  <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>std_msgs</depend>

--- a/autoware_planning_msgs/package.xml
+++ b/autoware_planning_msgs/package.xml
@@ -15,6 +15,7 @@
   <build_depend>rosidl_default_generators</build_depend>
 
   <depend>builtin_interfaces</depend>
+  <depend>autoware_common_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>std_msgs</depend>

--- a/autoware_planning_msgs/srv/ClearRoute.srv
+++ b/autoware_planning_msgs/srv/ClearRoute.srv
@@ -1,0 +1,2 @@
+---
+autoware_common_msgs/ResponseStatus status

--- a/autoware_planning_msgs/srv/SetLaneletRoute.srv
+++ b/autoware_planning_msgs/srv/SetLaneletRoute.srv
@@ -1,0 +1,7 @@
+std_msgs/Header header
+geometry_msgs/Pose goal_pose
+autoware_planning_msgs/LaneletSegment[] segments
+unique_identifier_msgs/UUID uuid
+bool allow_modification
+---
+autoware_common_msgs/ResponseStatus status

--- a/autoware_planning_msgs/srv/SetWaypointRoute.srv
+++ b/autoware_planning_msgs/srv/SetWaypointRoute.srv
@@ -1,0 +1,7 @@
+std_msgs/Header header
+geometry_msgs/Pose goal_pose
+geometry_msgs/Pose[] waypoints
+unique_identifier_msgs/UUID uuid
+bool allow_modification
+---
+autoware_common_msgs/ResponseStatus status


### PR DESCRIPTION
## Description
This will promote route related services from autoware_internal_planning_msgs to autoware_planning_msgs so that it can be used by AD API as component interface. 

I will deprecated the messages in autoware_internal_planning_msgs once this PR is merged.

## How was this PR tested?
I have tested that build passes on my local machine.

## Notes for reviewers

None.

## Effects on system behavior

None.
