### PR TITLE
refactor(autoware_msgs): add USE_SCOPED_HEADER_INSTALL_DIR

### DIFF
--- a/autoware_common_msgs/CMakeLists.txt
+++ b/autoware_common_msgs/CMakeLists.txt
@@ -9,4 +9,4 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_control_msgs/CMakeLists.txt
+++ b/autoware_control_msgs/CMakeLists.txt
@@ -23,4 +23,4 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_localization_msgs/CMakeLists.txt
+++ b/autoware_localization_msgs/CMakeLists.txt
@@ -23,4 +23,4 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_map_msgs/CMakeLists.txt
+++ b/autoware_map_msgs/CMakeLists.txt
@@ -35,4 +35,4 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_perception_msgs/CMakeLists.txt
+++ b/autoware_perception_msgs/CMakeLists.txt
@@ -35,4 +35,4 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_planning_msgs/CMakeLists.txt
+++ b/autoware_planning_msgs/CMakeLists.txt
@@ -33,4 +33,4 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_sensing_msgs/CMakeLists.txt
+++ b/autoware_sensing_msgs/CMakeLists.txt
@@ -30,4 +30,4 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_system_msgs/CMakeLists.txt
+++ b/autoware_system_msgs/CMakeLists.txt
@@ -26,4 +26,4 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_v2x_msgs/CMakeLists.txt
+++ b/autoware_v2x_msgs/CMakeLists.txt
@@ -19,4 +19,4 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_vehicle_msgs/CMakeLists.txt
+++ b/autoware_vehicle_msgs/CMakeLists.txt
@@ -32,4 +32,4 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)


### PR DESCRIPTION
## Description

This PR adds `USE_SCOPED_HEADER_INSTALL_DIR` to existing `ament_auto_package()` calls in `autoware_msgs`.

Updated packages:
- `autoware_common_msgs`
- `autoware_control_msgs`
- `autoware_localization_msgs`
- `autoware_map_msgs`
- `autoware_perception_msgs`
- `autoware_planning_msgs`
- `autoware_sensing_msgs`
- `autoware_system_msgs`
- `autoware_v2x_msgs`
- `autoware_vehicle_msgs`

## How was this PR tested?

Built the target packages locally:
```bash
colcon build --base-paths ~/autoware_scoped_headers/autoware/src \
  --symlink-install \
  --cmake-args -DCMAKE_BUILD_TYPE=Release \
  --packages-select \
  autoware_common_msgs \
  autoware_control_msgs \
  autoware_localization_msgs \
  autoware_map_msgs \
  autoware_perception_msgs \
  autoware_planning_msgs \
  autoware_sensing_msgs \
  autoware_system_msgs \
  autoware_v2x_msgs \
  autoware_vehicle_msgs
```

All packages built successfully.

## Notes for reviewers

This is part of the follow-up work after adding `USE_SCOPED_HEADER_INSTALL_DIR` support to `autoware_cmake`.

## Interface changes

None.

## Effects on system behavior

No functional behavior change. This updates the package macro options for the scoped header installation migration.