### PR TITLE
ci: update GitHub Actions runner from ubuntu-22.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -25,7 +25,7 @@ jobs:
   build-and-test-differential:
     needs: make-sure-label-is-present
     if: ${{ needs.make-sure-label-is-present.outputs.result == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build-and-test:
     if: ${{ github.event_name != 'push' || github.ref_name == github.event.repository.default_branch }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false

--- a/.github/workflows/bump-new-version.yaml
+++ b/.github/workflows/bump-new-version.yaml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   update-versions:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/comment-on-pr.yaml
+++ b/.github/workflows/comment-on-pr.yaml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   comment-on-pr:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   github-release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Set tag name
         id: set-tag-name

--- a/.github/workflows/pre-commit-optional.yaml
+++ b/.github/workflows/pre-commit-optional.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   pre-commit-optional:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   pre-commit:
     if: ${{ github.event.repository.private }} # Use pre-commit.ci for public repositories
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/release-new-version-when-merged.yaml
+++ b/.github/workflows/release-new-version-when-merged.yaml
@@ -12,7 +12,7 @@ jobs:
         join(github.event.pull_request.labels.*.name, ','),
         'release:bump-version'
       )
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/spell-check-daily.yaml
+++ b/.github/workflows/spell-check-daily.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   spell-check-daily:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/spell-check-differential.yaml
+++ b/.github/workflows/spell-check-differential.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   spell-check-differential:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/sync-files.yaml
+++ b/.github/workflows/sync-files.yaml
@@ -22,7 +22,7 @@ jobs:
   sync-files:
     needs: check-secret
     if: ${{ needs.check-secret.outputs.set == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/update-codeowners-from-packages.yaml
+++ b/.github/workflows/update-codeowners-from-packages.yaml
@@ -22,7 +22,7 @@ jobs:
   update-codeowners-from-packages:
     needs: check-secret
     if: ${{ needs.check-secret.outputs.set == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token


### PR DESCRIPTION
## Summary
- Update GitHub Actions `runs-on` runners from `ubuntu-22.04` to `ubuntu-24.04`
- `ubuntu-22.04-m` and other variant runners are unchanged

## Test plan
- [ ] Verify CI workflows pass on ubuntu-24.04 runners

Made with [Cursor](https://cursor.com)